### PR TITLE
fixed Color palette glitches

### DIFF
--- a/src/main/webapp/css/style.css
+++ b/src/main/webapp/css/style.css
@@ -21,14 +21,26 @@
   max-height:175px;
   margin: auto;
   width:60%;
-  padding: 0px 10px 15px;
+  padding: 40px 10px 15px;
   border: 1px solid rgba(0, 0, 0, 0.308);
   border-radius: 5px;
-  overflow: auto;
+  overflow-y: hidden;
+  overflow-x: auto;
   position: fixed;
+  white-space: nowrap;
   left: 20%;
   top: 3%;
   background-color: rgba(255, 255, 255, 0.466);
+}
+
+h3 {
+  max-height:175px;
+  margin: auto;
+  width:60%;
+  padding: 10px;
+  position: fixed;
+  left: 20%;
+  top: 3%;
 }
 
 .pallette-holder :hover {

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -8,8 +8,9 @@
     </head>
     <body onload="getActive()">
       <div id="pallette-section">
+        <h3 style="text-align:center;">Color Palette</h3>
         <div class="pallette-holder" id="palette">
-          <h3 style="text-align:center;">Color Palette</h3>
+          <!-- <h3 style="text-align:center;">Color Palette</h3> -->
           <button class="palette-button active" id="color1" style="background-color: #8BCBC8;">1</button>
           <button class="palette-button" id="color2" style="background-color: #ECC7C0;">2</button>
           <button class="palette-button" id="color3" style="background-color: #FDAE84;">3</button>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -10,7 +10,6 @@
       <div id="pallette-section">
         <h3 style="text-align:center;">Color Palette</h3>
         <div class="pallette-holder" id="palette">
-          <!-- <h3 style="text-align:center;">Color Palette</h3> -->
           <button class="palette-button active" id="color1" style="background-color: #8BCBC8;">1</button>
           <button class="palette-button" id="color2" style="background-color: #ECC7C0;">2</button>
           <button class="palette-button" id="color3" style="background-color: #FDAE84;">3</button>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -9,6 +9,7 @@
     <body onload="getActive()">
       <div id="pallette-section">
         <div class="pallette-holder" id="palette">
+          <h3 style="text-align:center;">Color Palette</h3>
           <button class="palette-button active" id="color1" style="background-color: #8BCBC8;">1</button>
           <button class="palette-button" id="color2" style="background-color: #ECC7C0;">2</button>
           <button class="palette-button" id="color3" style="background-color: #FDAE84;">3</button>


### PR DESCRIPTION
When i pulled from master, i guess the "color palette" heading wasn't transferred so i readded that. 
Next, there was a glitch where if you hovered over the "color palette" title it would do the whole "active" thing where it made the whole heading bigger and put a border around it as if you were hovering over the buttons. i fixed that glitch. 
Lastly, yemi's code for the scrollable palette didn't go through to master or maybe got overrided at some point, so i added that back in there!